### PR TITLE
Display previously logged into servers, with saved credentials 

### DIFF
--- a/src/components/ogre/widgets/ServerBrowser.layout
+++ b/src/components/ogre/widgets/ServerBrowser.layout
@@ -11,7 +11,7 @@
 			<Property Name='UnifiedSize' Value='{{1.0,-2.0},{1.0,-35.0}}'/>
 			<Property Name='InheritsAlpha' Value='true'/>
 			<Property Name='SelectionMode' Value='RowSingle'/>
-			<Property Name='ColumnHeader' Value='text:Account width:{0.15, 0} id:0'/>
+			<Property Name='ColumnHeader' Value='text:   width:{0.1, 0} id:0'/>
 			<Property Name='ColumnHeader' Value='text:Server Name width:{0.30, 0} id:1'/>
 			<Property Name='ColumnHeader' Value='text:Ping width:{0.1, 0} id:2'/>
 			<Property Name='ColumnHeader' Value='text:Clients width:{0.1, 0} id:3'/>

--- a/src/components/ogre/widgets/ServerBrowser.lua
+++ b/src/components/ogre/widgets/ServerBrowser.lua
@@ -229,11 +229,14 @@ function ServerBrowser:getSavedAccount(sInfo)
 	-- We are always expecting a string ... even if it's empty.
 	local serverService = emberServices:getServerSettingsService()
 	local serverSettingCredentials = Ember.Services.ServerSettingsCredentials:new(sInfo:getHostname(), sInfo:getServername())
-
 	local savedUser = serverService:getItem(serverSettingCredentials,"username" )
-	
-	return savedUser:as_string()
+	local retFav = ""
 
+	if savedUser ~= "" then
+		retFav = "***"
+	end
+
+	return retFav
 end
 
 function ServerBrowser:MetaServer_ReceivedServerInfo(sInfo)


### PR DESCRIPTION
Added the saved user, if any to the server browser to allow someone to distinguish what servers they have saved credentials for.  As per the blueprint:

https://blueprints.launchpad.net/ember/+spec/ember-mark-favourite-servers
