### PR TITLE
Add boost/shard_ptr.hpp include for Lucid

### DIFF
--- a/src/components/ogre/EntityWorldPickListener.cpp
+++ b/src/components/ogre/EntityWorldPickListener.cpp
@@ -40,6 +40,8 @@
 
 #include <Eris/View.h>
 
+#include <boost/shared_ptr.hpp>
+
 namespace Ember
 {
 namespace OgreView

--- a/src/components/ogre/terrain/TerrainEditorOverlay.cpp
+++ b/src/components/ogre/terrain/TerrainEditorOverlay.cpp
@@ -47,6 +47,8 @@
 #include <OgreSceneNode.h>
 #include <OgreEntity.h>
 
+#include <boost/shared_ptr.hpp>
+
 #include <sigc++/bind.h>
 
 namespace Ember


### PR DESCRIPTION
I've no idea why this breaks on Lucid, and not my Fedora machines, but it does.
