### PR TITLE
Switch from WFMATH_EPSILON to WFMath::numeric_constants<CoordType>::epsilon()

### DIFF
--- a/src/components/ogre/model/ModelRepresentation.cpp
+++ b/src/components/ogre/model/ModelRepresentation.cpp
@@ -333,7 +333,7 @@ void ModelRepresentation::parseMovementMode(const WFMath::Vector<3>& velocity)
 	if (velocity != WFMath::Vector<3>::ZERO()) {
 		if (velocity.isValid()) {
 			//Use WFMATH_EPSILON to remove any rounding errors
-			if (velocity.x() + WFMATH_EPSILON < 0.0f) {
+			if (velocity.x() + WFMath::numeric_constants<WFMath::CoordType>::epsilon() < 0.0f) {
 				newMode = MM_WALKING_BACKWARDS;
 			} else {
 				if (velocity.mag() > 2.6) {


### PR DESCRIPTION
I updated the headers to remove the defines, and replace them with an API which allowed for different epsilon to be provided for different floating point type. This is required for Ember to compile.
