### PR TITLE
Fix minor boost compilation error

### DIFF
--- a/src/components/ogre/SceneManagers/EmberPagingSceneManager/src/OgrePagingLandScapeData2D.cpp
+++ b/src/components/ogre/SceneManagers/EmberPagingSceneManager/src/OgrePagingLandScapeData2D.cpp
@@ -116,7 +116,7 @@ void PagingLandScapeData2D::unload()
 			_save ();
 		//Use the shared pointer for deletion
 //		delete[] mHeightData;
-		mHeightDataPtr.reset(0);
+		mHeightDataPtr.reset();
 		mHeightData = 0;
 		_unload();
 		mIsLoaded = false;


### PR DESCRIPTION
For my setup, I had to change this in order for ember to build.
It is just a call to boost::shared_array.reset() which should not make a difference.

Versions:

g++:   4.8.0
boost: 1.53.0
Arch Linux x86_64
