### PR TITLE
Sunway:   Fixed issue, Player continues walking if mode changed during walk

### DIFF
--- a/src/components/ogre/MovementController.cpp
+++ b/src/components/ogre/MovementController.cpp
@@ -68,7 +68,11 @@ void MovementControllerInputListener::input_MouseButtonPressed(Input::MouseButto
 
 void MovementControllerInputListener::input_MouseButtonReleased(Input::MouseButton button, Input::InputMode mode)
 {
-	if (mode == Input::IM_MOVEMENT && button == Input::MouseButtonLeft) {
+	if (mode == Input::IM_GUI){
+		mController.mMovementDirection.x() = 0;
+		mController.mMovementDirection.y() = 0;
+		mController.mMovementDirection.z() = 0;	
+	}else if (mode == Input::IM_MOVEMENT && button == Input::MouseButtonLeft) {
 		mController.mMovementDirection.y() = 0;
 	}
 }


### PR DESCRIPTION
The player stops walking immediately on pressing the right mouse button, and I think it's more user-friendly compared to make it a feature for usage in long walks.
