### PR TITLE
Replace wget -c with curl -C - -OL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ releasemedia:
 #create a temporary directory
 	$(eval ourtempdir := $(shell mktemp -d))
 #get the file
-	wget http://downloads.sourceforge.net/worldforge/ember-media-$(VERSION).tar.bz2 -P $(ourtempdir)
+	curl -C - -OL http://downloads.sourceforge.net/worldforge/ember-media-$(VERSION).tar.bz2 -P $(ourtempdir)
 #unpack to our temporary directory
 	tar -jxf $(ourtempdir)/ember-media-$(VERSION).tar.bz2 -C $(ourtempdir)
 #move to the correct location


### PR DESCRIPTION
- Wget is less likely to be installed on linux systems
- LibcURL is a dependency of worldforge already
- `wget -c` is likely what you wanted (will continue incomplete downloads)
- `curl -C - -OL` is a drop in replacement
-  Reference github #12
