### PR TITLE
Skeleton bone_pile, and bone parts. 

### DIFF
--- a/data/dural/bone_pile.modeldef
+++ b/data/dural/bone_pile.modeldef
@@ -1,0 +1,147 @@
+<models>
+    <model name="bone_pile" usescaleof="all" showcontained="false" icon="">
+        <translate x="0" y="0" z="0" />
+        <rotation x="1" y="0" z="0" degrees="0" />
+        <submodels>
+            <submodel mesh="dural/creatures/biped/skeleton/model/bone_pile.mesh">
+                <parts>
+                    <part name="RFoot" show="false">
+                        <subentities>
+                            <subentity index="0" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="LFoot" show="false">
+                        <subentities>
+                            <subentity index="1" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="RShin" show="false">
+                        <subentities>
+                            <subentity index="2" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="LShin" show="false">
+                        <subentities>
+                            <subentity index="3" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="LKnee" show="false">
+                        <subentities>
+                            <subentity index="4" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="RKnee" show="false">
+                        <subentities>
+                            <subentity index="5" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="RThigh" show="false">
+                        <subentities>
+                            <subentity index="6" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="LThigh" show="false">
+                        <subentities>
+                            <subentity index="7" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="Hips" show="false">
+                        <subentities>
+                            <subentity index="8" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="LowerSpine" show="false">
+                        <subentities>
+                            <subentity index="9" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="MiddleSpine" show="false">
+                        <subentities>
+                            <subentity index="10" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="UpperSpine" show="false">
+                        <subentities>
+                            <subentity index="11" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="Ribcage" show="false">
+                        <subentities>
+                            <subentity index="12" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="RScapula" show="false">
+                        <subentities>
+                            <subentity index="13" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="LScapula" show="false">
+                        <subentities>
+                            <subentity index="14" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="RClavicle" show="false">
+                        <subentities>
+                            <subentity index="15" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="LClavicle" show="false">
+                        <subentities>
+                            <subentity index="16" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="RUpperArm" show="false">
+                        <subentities>
+                            <subentity index="17" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="LUpperArm" show="false">
+                        <subentities>
+                            <subentity index="18" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="RForeArm" show="false">
+                        <subentities>
+                            <subentity index="19" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="LForeArm" show="false">
+                        <subentities>
+                            <subentity index="20" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="RHand" show="false">
+                        <subentities>
+                            <subentity index="21" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="LHand" show="false">
+                        <subentities>
+                            <subentity index="22" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="Jaw" show="false">
+                        <subentities>
+                            <subentity index="23" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="Neck" show="false">
+                        <subentities>
+                            <subentity index="24" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                    <part name="Skull" show="false">
+                        <subentities>
+                            <subentity index="25" material="/dural/creatures/biped/skeleton/textures" />
+                        </subentities>
+                    </part>
+                </parts>
+            </submodel>
+        </submodels>
+        <actions />
+        <attachpoints />
+        <views />
+        <lights />
+        <bonegroups />
+    </model>
+</models>

--- a/data/dural/entitymappings.entitymap.xml
+++ b/data/dural/entitymappings.entitymap.xml
@@ -1060,13 +1060,18 @@
 				</entitymatch>-->
 			</case>
 		</entitymatch>
-	</entitymapping>	
-	<autoentitymapping name="arm" />
-	<autoentitymapping name="skull" />
-	<autoentitymapping name="shin" />
+	</entitymapping>
+
+	<autoentitymapping name="bone_pile" /> 
+	<autoentitymapping name="humerus" /> 
+	<autoentitymapping name="skull" /> 
+	<autoentitymapping name="tibia" />
 	<autoentitymapping name="pelvis" />
-	<autoentitymapping name="ribcage" />
-	<autoentitymapping name="thigh" />
+	<autoentitymapping name="ribcage" /> 
+	<autoentitymapping name="femur" />
+
+
+
 <!--	<entitymapping name="goblin">
 		<entitymatch>
 			<case>

--- a/data/dural/femur.modeldef
+++ b/data/dural/femur.modeldef
@@ -1,0 +1,16 @@
+<models>
+    <model name="femur" usescaleof="all" showcontained="true" icon="">
+        <translate x="0" y="0" z="0" />
+        <rotation x="1" y="0" z="0" degrees="0" />
+        <submodels>
+            <submodel mesh="dural/items/misc/femur/model/femur.mesh">
+                <parts />
+            </submodel>
+        </submodels>
+        <actions />
+        <attachpoints />
+        <views />
+        <lights />
+        <bonegroups />
+    </model>
+</models>

--- a/data/dural/fibula.modeldef
+++ b/data/dural/fibula.modeldef
@@ -1,0 +1,16 @@
+<models>
+    <model name="tibia" usescaleof="all" showcontained="true" icon="">
+        <translate x="0" y="0" z="0" />
+        <rotation x="1" y="0" z="0" degrees="0" />
+        <submodels>
+            <submodel mesh="dural/items/misc/tibia/model/tibia.mesh">
+                <parts />
+            </submodel>
+        </submodels>
+        <actions />
+        <attachpoints />
+        <views />
+        <lights />
+        <bonegroups />
+    </model>
+</models>

--- a/data/dural/humerus.modeldef
+++ b/data/dural/humerus.modeldef
@@ -1,0 +1,16 @@
+<models>
+    <model name="humerus" usescaleof="all" showcontained="true" icon="">
+        <translate x="0" y="0" z="0" />
+        <rotation x="1" y="0" z="0" degrees="0" />
+        <submodels>
+            <submodel mesh="dural/items/misc/humerus/model/humerus.mesh">
+                <parts />
+            </submodel>
+        </submodels>
+        <actions />
+        <attachpoints />
+        <views />
+        <lights />
+        <bonegroups />
+    </model>
+</models>

--- a/data/dural/pelvis.modeldef
+++ b/data/dural/pelvis.modeldef
@@ -1,0 +1,16 @@
+<models>
+    <model name="pelvis" usescaleof="all" showcontained="true" icon="">
+        <translate x="0" y="0" z="0" />
+        <rotation x="1" y="0" z="0" degrees="0" />
+        <submodels>
+            <submodel mesh="dural/items/misc/pelvis/model/pelvis.mesh">
+                <parts />
+            </submodel>
+        </submodels>
+        <actions />
+        <attachpoints />
+        <views />
+        <lights />
+        <bonegroups />
+    </model>
+</models>

--- a/data/dural/ribcage.modeldef
+++ b/data/dural/ribcage.modeldef
@@ -1,0 +1,16 @@
+<models>
+    <model name="ribcage" usescaleof="all" showcontained="true" icon="">
+        <translate x="0" y="0" z="0" />
+        <rotation x="1" y="0" z="0" degrees="0" />
+        <submodels>
+            <submodel mesh="dural/items/misc/ribcage/model/ribcage.mesh">
+                <parts />
+            </submodel>
+        </submodels>
+        <actions />
+        <attachpoints />
+        <views />
+        <lights />
+        <bonegroups />
+    </model>
+</models>

--- a/data/dural/skull.modeldef
+++ b/data/dural/skull.modeldef
@@ -1,0 +1,16 @@
+<models>
+    <model name="skull" usescaleof="all" showcontained="true" icon="">
+        <translate x="0" y="0" z="0" />
+        <rotation x="1" y="0" z="0" degrees="0" />
+        <submodels>
+            <submodel mesh="dural/items/misc/skull/model/skull.mesh">
+                <parts />
+            </submodel>
+        </submodels>
+        <actions />
+        <attachpoints />
+        <views />
+        <lights />
+        <bonegroups />
+    </model>
+</models>


### PR DESCRIPTION
Adding a bone_pile object for when the skeleton is defeated. Adding bone parts skull, pelvis, ribcage, femur, humerus, tibia as part of worldforge-media-skeleton-parts blueprint. Updated entitymappings to use these new models.

Blueprint: worldforge-media-skeleton-parts