### PR TITLE
Fix help widget

### DIFF
--- a/src/components/ogre/widgets/HelpWidget.layout
+++ b/src/components/ogre/widgets/HelpWidget.layout
@@ -11,47 +11,43 @@
             <Property name="HorzFormatting" value="WordWrapLeftAligned" />
             <Property name="VertFormatting" value="TopAligned" />
             <Property name="VertScrollbar" value="True" />
-			<Property name="Text">Welcome to ember. This help window can be accessed anytime either by clicking on the help icon down to the left, or by entering the command '/help' in the console (F12 will expand the console).
+			<Property name="Text">[colour='FFF05E1B']Welcome to Ember![colour='FF000000'] This help window can be accessed anytime either by clicking on the help icon down to the left, or by entering the command '/help' in the console (F12 will expand the console).&#xA;
 
----Getting started---
-The first thing you would want to do is to connect to a server. Use the server browser window for this. It should have connected to the metaserver and presented a list with available servers. You can also enter your own server address in the textbox in the lower left corner. Once connected, you must either create an account or log into an already existing. This is pretty straightforward. Once you've logged in, you must either choose an existing character, or create a new one. Also pretty self explanatory.
+---Getting started---&#xA;
+The first thing you would want to do is to connect to a server. Use the server browser window for this. It should have connected to the metaserver and presented a list with available servers. You can also enter your own server address in the textbox in the lower left corner. Once connected, you must either [colour='FFF05E1B']create an account or login[colour='FF000000'] to an already existing one. This is pretty straightforward. Once you've logged in, you must either [colour='FFF05E1B']choose an existing character, or create a new one.[colour='FF000000']&#xA;
 
----Moving in the world---
-When you enter the world, you'll switch from 'gui mode' to 'movement mode'. You can at any time switch between these two modes with a right click on the mouse. Use the 'wasd' keys to move the avatar. Pressing shift will make the avatar run, though the server might not always keep up with this.
+---Moving in the world---&#xA;
+When you enter the world, you'll switch from 'gui mode' to 'movement mode'. You can switch at any time between these two modes with a right click on the mouse. [colour='FFF05E1B']Use the 'wasd' keys to move[colour='FF000000'] the avatar. Pressing shift will toggle slow walking.&#xA;
 
----Interacting with the world---
-Your main way of interacting with the world is by clicking with the left mouse button on world entities. This will bring up an action menu. Choose from the menu to perform the desired action.
- * Touch : this will make the avatar touch the entity, provoking different responses depending on the type of entity touched. A NPC will speak with you, while a pig might decide to try to run away from you. Try touching different entities in the world to find out their different responses.
- * Take : moves the entity to your inventory, it the server allows it.
- * Give : displays the Give dialog. Beware! Currently the server allows you to give almost anything to any entity, sometimes without the possibility to get it back.
- * Inspect : shows debug info about the entity.
- * Use : Tries to use the currently wielded entity on the selected entity. Try to use an axe with a tree, or a cleaver with a pig.
+---Interacting with the world---&#xA;
+Your main way of [colour='FFF05E1B']interacting[colour='FF000000'] with the world is by clicking with the [colour='FFF05E1B']left mouse button[colour='FF000000'] on world entities. This will bring up an action menu. Choose from the menu to perform the desired action.&#xA;
+ * Move to: Makes you walk to this entity.&#xA;
+ * Pick up : moves the entity to your inventory, it the server allows it.&#xA;
+ * Inspect : shows debug info about the entity (terrain editing mode only).&#xA;
+ * Use : Tries to use the currently wielded entity on the selected entity. Try to use an axe on a tree, or a cleaver on a pig. The text depends on the entity you are wielding.&#xA;&#xA;
 
----Inventory---
-Down to the right is your inventory. You can drop or wield items in your inventory. Wielding means that that entity will be used when performing the 'Use' action on another entity.
+---Inventory---&#xA;
+Down to the right is your inventory. You can drop or wield items in your inventory. Wielding means that that entity will be used when performing the 'Use' action on another entity.&#xA;
 
---- Console ---
-At the top of the screen is the console. It can be expanded and shrunk by pressing F12. The console serves two purposes: it allows you to say things in the world, and it allows you to enter commands to the client. All commands are prefixed by '/', for example '/hide_chat' and '/show_chat'. Enter '/list_commands' for a list of all commands.
+--- Console ---&#xA;
+At the bottom left of the screen is the console. It can be expanded and shrunk by pressing F12. The console serves two purposes: it allows you to say things in the world, and it allows you to enter commands to the client. All commands are prefixed by '/', for example '/hide_chat' and '/show_chat'. Enter '/list_commands' for a list of all commands.&#xA;
 
---- Commands and keys ---
-Here's a list of the most common keys and some useful commands:
- When in movement mode:
-  w : forward
-  s : back
-  a : left
-  d : right
-  shift : run
- General keys:
-  F12 : toggle console
-  PrintScreen : take screenshot and save to ~/.local/share/ember/screenshots or c:\Document and Settings\$user\Application Data\ember\screenshots
-  F7 : toggle wireframe mode
-  F6 : toggle free flying mode
- Commands:
-  /quit : quits
-  /connect &lt;server&gt; : connects to a server
-  /login &lt;name&gt; &lt;password&gt; : tries to log in
-  /add &lt;name&gt; &lt;sex&gt; &lt;type&gt; : adds a new character, for example: /add Erik male settler
-  /list_commands : lists all available commands
+--- Commands and keys ---&#xA;
+Here's a list of the most common keys and some useful commands:&#xA;
+ When in movement mode:&#xA;
+  wasd : move&#xA;
+  shift : run&#xA;
+ General keys:&#xA;
+  F12 : toggle console&#xA;
+  PrintScreen : take screenshot and save to ~/.local/share/ember/screenshots or C:\Document and Settings\$user\Application Data\ember\screenshots&#xA;
+  F7 : toggle wireframe mode&#xA;
+  F6 : toggle free flying mode&#xA;
+ Commands:&#xA;
+  /quit : quits&#xA;
+  /connect &lt;server&gt; : connects to a server&#xA;
+  /login &lt;name&gt; &lt;password&gt; : tries to log in&#xA;
+  /add &lt;name&gt; &lt;sex&gt; &lt;type&gt; : adds a new character, for example: /add Erik male settler&#xA;
+  /list_commands : lists all available commands&#xA;
 For more questions or info, see www.worldforge.org
 			</Property>
 		</Window>


### PR DESCRIPTION
Fixes #35.

Before:

![](https://user-images.githubusercontent.com/59517351/167314926-f705cbcb-841c-4349-95e3-1f63760fd90f.png)

After:

![ember help](https://user-images.githubusercontent.com/59517351/180587128-f0bbbc70-d707-4ba6-aca0-6b5e995cbe72.png)

Description of solution: Adds line feed (`&#xA;`) characters. Also highlighted some essential stuff in ember orange and did some rewording and updating where necessary. The help is still by no means perfect but it is better than before. More specifically some padding would benefit the headings, usage of a bold font would also be cool. I did look into the cegui docs but especially the bold font part looks difficult here.

Testing: Applied changes locally. Since these cegui files do not need to be compiled, I can swap them out and restart ember to see the change.